### PR TITLE
Rename some config properties and minor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # kafka-sink-graphdb
-Kafka Sink Connector for Smart Update streaming to GraphDB
+Kafka Sink Connector for RDF update streaming to GraphDB
 
 # Docker & Docker Compose
 
 A [Dockerfile](./Dockerfile) is available for building the sink connector as a docker image.
 It is a multistage dockerfile which builds, tests and in the final stage copies the connector on the `plugin.path`.
 
-The image is based on confluent kafka connect [confluentinc/cp-kafka-connect](https://hub.docker.com/r/confluentinc/cp-kafka-connect) image.
+The image is based on Confluent Kafka Connect [confluentinc/cp-kafka-connect](https://hub.docker.com/r/confluentinc/cp-kafka-connect) image.
 
-Inside the [docker-compose](./docker-compose) directory there is an example compose file which sets everything up - zookeeper, kafka, graphdb and kafka connect.
+Inside the [docker-compose](./docker-compose) directory there is an example compose file that sets everything up - ZooKeeper, Kafka, GraphDB and Kafka Connect.
 In the same directory the [run.sh](./docker-compose/run.sh) script can be used to quickly test the sink connector.
 
 The script will do the following:
@@ -18,7 +18,7 @@ The script will do the following:
 1. wait for GraphDB and kafka connect to start
 2. create a GraphDB repository named "test"
 3. create the kafka-sink-graphdb connector
-4. using the kafka console producer - produce a simple triple (<urn:a> <urn:b> <urn:c> ) to the test topic
+4. using the Kafka console producer - produce a simple triple (<urn:a> <urn:b> <urn:c> ) to the test topic
 
 If all goes well you should see the triple in GraphDB:
 1. open http://localhost:7200/sparql

--- a/docker-compose/run.sh
+++ b/docker-compose/run.sh
@@ -33,13 +33,13 @@ function create_kafka_sink_connector {
 				"topics":"test",
 				"tasks.max":"1",
 				"offset.storage.file.filename": "/tmp/storage",
-				"graphdb.server.iri": "http://graphdb:7200",
+				"graphdb.server.url": "http://graphdb:7200",
 				"graphdb.server.repository": "test",
 				"graphdb.batch.size": 64,
 				"graphdb.batch.commit.limit.ms": 1000,
 				"graphdb.auth.type": "NONE",
-				"graphdb.transaction.type": "ADD",
-				"graphdb.transaction.rdf.format": "nq"
+				"graphdb.update.type": "ADD",
+				"graphdb.update.rdf.format": "nq"
 			}
 		}' http://localhost:8083/connectors -w "\n"
 	fi

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<artifactId>kafka-sink-graphdb</artifactId>
 	<version>1.0-SNAPSHOT</version>
 	<name>GraphDB Kafka Sink Connector</name>
-	<description>Kafka Sink Connector for Smart Update streaming to GraphDB</description>
+	<description>Kafka Sink Connector for RDF update streaming to GraphDB</description>
 
 	<properties>
 		<graphdb.version>9.9.0</graphdb.version>

--- a/src/main/java/com/ontotext/kafka/GraphDBSinkConfig.java
+++ b/src/main/java/com/ontotext/kafka/GraphDBSinkConfig.java
@@ -62,8 +62,8 @@ public class GraphDBSinkConfig extends AbstractConfig {
 		}
 	}
 
-	public static final String SERVER_IRI = "graphdb.server.iri";
-	public static final String SERVER_IRI_DOC = "GraphDB Server connection IRI";
+	public static final String SERVER_IRI = "graphdb.server.url";
+	public static final String SERVER_IRI_DOC = "GraphDB Server connection URL";
 
 	public static final String REPOSITORY = "graphdb.server.repository";
 	public static final String REPOSITORY_DOC = "Repository to which data is streamed";
@@ -73,22 +73,22 @@ public class GraphDBSinkConfig extends AbstractConfig {
 	public static final String DEFAULT_AUTH_TYPE = "NONE";
 
 	public static final String AUTH_BASIC_USER = "graphdb.auth.basic.username";
-	public static final String AUTH_BASIC_USER_DOC = "GraphDB basic security username";
+	public static final String AUTH_BASIC_USER_DOC = "GraphDB basic authentication username";
 	public static final String DEFAULT_AUTH_BASIC_USER = "admin";
 
 	public static final String AUTH_BASIC_PASS = "graphdb.auth.basic.password";
-	public static final String AUTH_BASIC_PASS_DOC = "GraphDB basic security password";
+	public static final String AUTH_BASIC_PASS_DOC = "GraphDB basic authentication password";
 	public static final String DEFAULT_AUTH_BASIC_PASS = "root";
 
 	public static final String AUTH_HEADER_TOKEN = "graphdb.auth.header.token";
 	public static final String AUTH_HEADER_TOKEN_DOC = "GraphDB custom header token";
 
-	public static final String RDF_FORMAT = "graphdb.transaction.rdf.format";
+	public static final String RDF_FORMAT = "graphdb.update.rdf.format";
 	public static final String DEFAULT_RDF_TYPE = "ttl";
 	public static final String RDF_FORMAT_DOC = "The RDF format for streaming data to GraphDB";
 
-	public static final String TRANSACTION_TYPE = "graphdb.transaction.type";
-	public static final String TRANSACTION_TYPE_DOC = "The RDF update transaction type";
+	public static final String TRANSACTION_TYPE = "graphdb.update.type";
+	public static final String TRANSACTION_TYPE_DOC = "The RDF update type";
 	public static final String DEFAULT_TRANSACTION_TYPE = "ADD";
 
 	public static final String BATCH_SIZE = "graphdb.batch.size";

--- a/src/main/java/com/ontotext/kafka/service/GraphDBService.java
+++ b/src/main/java/com/ontotext/kafka/service/GraphDBService.java
@@ -82,7 +82,7 @@ public class GraphDBService {
 	private SinkRecordsProcessor fetchProcessor(String transactionType, String rdfFormat, String templateId) {
 		GraphDBSinkConfig.TransactionType type = GraphDBSinkConfig.TransactionType.of(transactionType);
 		if (type == null) {
-			throw new IllegalArgumentException("Invalid transaction type: " + transactionType);
+			throw new IllegalArgumentException("Invalid update type: " + transactionType);
 		}
 		switch (type) {
 			case ADD:

--- a/src/main/java/com/ontotext/kafka/service/SinkRecordsProcessor.java
+++ b/src/main/java/com/ontotext/kafka/service/SinkRecordsProcessor.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 import com.ontotext.kafka.error.ErrorHandler;
 
 /**
- * A processor which batches sink records and flushes the smart updates to a given
+ * A processor which batches sink records and flushes the updates to a given
  * GraphDB {@link org.eclipse.rdf4j.repository.http.HTTPRepository}.
  * <p>
  * Batches that do not meet the {@link com.ontotext.kafka.GraphDBSinkConfig#BATCH_SIZE} are flushed

--- a/src/main/java/com/ontotext/kafka/util/ValidateGraphDBConnection.java
+++ b/src/main/java/com/ontotext/kafka/util/ValidateGraphDBConnection.java
@@ -94,7 +94,7 @@ public class ValidateGraphDBConnection {
 					                                                 .getContent(), StandardCharsets.UTF_8)).getString("productVersion");
 			} catch (JSONException e) {
 				throw new ConfigException(SERVER_IRI, serverIri.value(),
-					"No GraphDB running on the provided GraphDB server iri");
+					"No GraphDB running on the provided GraphDB server URL");
 			}
 			String[] versionSplits = version.split("[.\\-]");
 			if (Integer.parseInt(versionSplits[0]) < 10 && Integer.parseInt(versionSplits[1]) < 10) {
@@ -104,7 +104,7 @@ public class ValidateGraphDBConnection {
 			}
 		} catch (IOException e) {
 			throw new ConfigException(SERVER_IRI, serverIri.value(),
-				"No GraphDB running on the provided GraphDB server iri");
+				"No GraphDB running on the provided GraphDB server URL");
 		}
 	}
 

--- a/src/main/resources/graphdb-kafka-sink.properties
+++ b/src/main/resources/graphdb-kafka-sink.properties
@@ -16,7 +16,7 @@
 name=GraphDBSinkConnector
 connector.class=com.ontotext.kafka.GraphDBSinkConnector
 
-graphdb.server.iri=Type: String;\nDescription: GraphDB Server IRI
+graphdb.server.url=Type: String;\nDescription: GraphDB Server URL
 graphdb.server.repository=Type: String;\nDescription: GraphDB Repository
 
 graphdb.batch.size=Type: Int;
@@ -26,9 +26,9 @@ graphdb.auth.basic.username=Type: String;
 graphdb.auth.basic.password=Type: String;
 graphdb.auth.header.token=Type: String;\nDescription: GraphDB Auth Token
 
-graphdb.transaction.type=Type: enum[ADD, REPLACE_GRAPH, SMART_UPDATE];\nDescription: Transaction type (default NONE)
-graphdb.transaction.rdf.format=Type: enum[rdf, rdfs, xml, owl, nt, ttl, ttls, n3, xml, trix, trig, trigs, brf, nq, jsonld, ndjsonld, jsonl, ndjson, rj, xhtml, html, hdt];\nDescription: Transaction type (default NONE)
-graphdb.transaction.timeout.ms=Type: Long;\nDescription: Transaction timeout for smart update (default 30000)
+graphdb.update.type=Type: enum[ADD, REPLACE_GRAPH, SMART_UPDATE];\nDescription: Transaction type (default NONE)
+graphdb.update.rdf.format=Type: enum[rdf, rdfs, xml, owl, nt, ttl, ttls, n3, xml, trix, trig, trigs, brf, nq, jsonld, ndjsonld, jsonl, ndjson, rj, xhtml, html, hdt];\nDescription: Transaction type (default NONE)
+graphdb.batch.commit.limit.ms=Type: Long;\nDescription: The timeout applied per batch that is not full before it is committed (default 3000)
 
 #graphdb.connection.pool.size=Type: Int;\nDescription: Connection pool size (default 5)
 

--- a/src/test/java/com/ontotext/kafka/ConfigurationValidationTest.java
+++ b/src/test/java/com/ontotext/kafka/ConfigurationValidationTest.java
@@ -52,9 +52,9 @@ public class ConfigurationValidationTest {
 					put("graphdb.auth.type", "basic");
 					put("graphdb.auth.basic.username", "johnnyawesome");
 					put("graphdb.auth.basic.password", "luben1");
-					put("graphdb.transaction.type", "ADD");
-					put("graphdb.transaction.rdf.format", "nq");
-					put("graphdb.server.iri", "http://localhost:12345/");
+					put("graphdb.update.type", "ADD");
+					put("graphdb.update.rdf.format", "nq");
+					put("graphdb.server.url", "http://localhost:12345/");
 					put("graphdb.server.repository", "Test");
 				}
 			};
@@ -73,7 +73,7 @@ public class ConfigurationValidationTest {
 		configs =
 			new HashMap<>() {
 				{
-					put("graphdb.server.iri", "http://localhost:12345/");
+					put("graphdb.server.url", "http://localhost:12345/");
 					put("graphdb.server.repository", "Test");
 				}
 			};
@@ -92,7 +92,7 @@ public class ConfigurationValidationTest {
 		configs =
 			new HashMap<>() {
 				{
-					put("graphdb.server.iri", "http://localhost:12345/");
+					put("graphdb.server.url", "http://localhost:12345/");
 					put("graphdb.server.repository", "Test");
 					put("graphdb.auth.type", "basic");
 					put("graphdb.auth.basic.username", "invalid");
@@ -116,14 +116,14 @@ public class ConfigurationValidationTest {
 		configs =
 			new HashMap<>() {
 				{
-					put("graphdb.server.iri", "http://localhost:12345/");
+					put("graphdb.server.url", "http://localhost:12345/");
 					put("graphdb.server.repository", "Test");
 				}
 			};
 		results = sinkconnector.validate(configs).configValues();
 		mockedGraphDBClient.reset();
 		Assertions.assertTrue(results.stream()
-			                      .filter(cv -> cv.name().equals("graphdb.server.iri"))
+			                      .filter(cv -> cv.name().equals("graphdb.server.url"))
 			                      .noneMatch(cv -> cv.errorMessages().isEmpty()),
 			"Didn't get an error for GraphDB version");
 	}
@@ -135,13 +135,13 @@ public class ConfigurationValidationTest {
 		configs =
 			new HashMap<>() {
 				{
-					put("graphdb.server.iri", "http://localhost:12345/");
+					put("graphdb.server.url", "http://localhost:12345/");
 					put("graphdb.server.repository", "Test");
 				}
 			};
 		results = sinkconnector.validate(configs).configValues();
 		Assertions.assertTrue(results.stream()
-			                      .filter(cv -> cv.name().equals("graphdb.server.iri"))
+			                      .filter(cv -> cv.name().equals("graphdb.server.url"))
 			                      .noneMatch(cv -> cv.errorMessages().isEmpty()),
 			"Didn't get an error for missing GraphDB");
 	}
@@ -150,8 +150,8 @@ public class ConfigurationValidationTest {
 	@CsvSource({ "graphdb.batch.size, 5a",
 		"graphdb.batch.commit.limit.ms, 3000a",
 		"graphdb.auth.type, noners",
-		"graphdb.transaction.type, ADDer",
-		"graphdb.transaction.rdf.format, nqq" })
+		"graphdb.update.type, ADDer",
+		"graphdb.update.rdf.format, nqq" })
 	@DisplayName("Test wrong configs")
 	@Timeout(5)
 	void testWithWrongValues(String key, String value) {
@@ -159,7 +159,7 @@ public class ConfigurationValidationTest {
 			new HashMap<>() {
 				{
 					put(key, value);
-					put("graphdb.server.iri", "1");
+					put("graphdb.server.url", "1");
 					put("graphdb.server.repository", "2");
 				}
 			};


### PR DESCRIPTION
Rename some config properties to better fit how we call these things elsewhere:

* graphdb.server.iri => graphdb.server.url
* graphdb.transaction.type => graphdb.update.type
* graphdb.transaction.rdf.format => graphdb.update.rdf.format

Minor cleanup of README.md

Removed some unnecessary references to "smart update"