### PR TITLE
Handle null records in REPLACE_GRAPH update type

### DIFF
--- a/src/main/java/com/ontotext/kafka/service/ReplaceGraphProcessor.java
+++ b/src/main/java/com/ontotext/kafka/service/ReplaceGraphProcessor.java
@@ -36,7 +36,9 @@ public class ReplaceGraphProcessor extends SinkRecordsProcessor {
 		try {
 			Resource context = ValueUtil.convertIRIKey(record.key());
 			connection.clear(context);
-			connection.add(ValueUtil.convertRDFData(record.value()), format, context);
+			if (record.value() != null) {
+				connection.add(ValueUtil.convertRDFData(record.value()), format, context);
+			}
 
 		} catch (IOException e) {
 			throw new RetriableException(e.getMessage());


### PR DESCRIPTION
Resolves issue: https://github.com/Ontotext-AD/kafka-sink-graphdb/issues/21