### PR TITLE
GDB-9300 Upgraded kafka versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ RUN \
   unzip /tmp/kafka-sink-graphdb/target/kafka-sink-graphdb-plugin.zip -d target/
 
 # Final stage - kafka sink worker
-FROM confluentinc/cp-kafka-connect:6.2.0
+FROM confluentinc/cp-kafka-connect:7.5.3
 
 COPY --from=builder /tmp/kafka-sink-graphdb/target/kafka-sink-graphdb /usr/share/java/kafka-sink-graphdb

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:6.2.0
+    image: confluentinc/cp-zookeeper:7.5.3
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -12,7 +12,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-enterprise-kafka:6.2.0
+    image: confluentinc/cp-enterprise-kafka:7.5.3
     hostname: broker
     container_name: broker
     depends_on:
@@ -36,7 +36,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: anonymous
 
   graphdb:
-    image: ontotext/graphdb:10.2.0
+    image: ontotext/graphdb:10.5.0
     hostname: graphdb
     container_name: graphdb
     ports:

--- a/pom.xml
+++ b/pom.xml
@@ -9,17 +9,17 @@
 	<description>Kafka Sink Connector for RDF update streaming to GraphDB</description>
 
 	<properties>
-		<graphdb.version>10.5.0</graphdb.version>
         <kafka.version>3.5.2</kafka.version>
-		<slf4j.version>1.7.36</slf4j.version>
-        <jackson.version>2.10.1</jackson.version>
+		<slf4j.version>2.0.5</slf4j.version>
+        <jackson.version>2.15.3</jackson.version>
         <java.level>11</java.level>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <confluent.serializer.version>7.5.3</confluent.serializer.version>
 		<rdf4j.version>4.3.8</rdf4j.version>
 		<confluent.connect.plugin.version>0.12.0</confluent.connect.plugin.version>
         <avro.version>1.11.3</avro.version>
-		<dependency.check.version>7.4.4</dependency.check.version>
+		<dependency.check.version>8.4.3</dependency.check.version>
+		<jetty.version>9.4.53.v20231009</jetty.version>
+		<apache.maven.version>3.9.6</apache.maven.version>
 		<docker.maven.version>0.40.2</docker.maven.version>
 		<dockerImageTag>${project.version}</dockerImageTag>
 
@@ -181,6 +181,68 @@
 		</repository>
 	</repositories>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.fasterxml.jackson</groupId>
+				<artifactId>jackson-bom</artifactId>
+				<version>${jackson.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-core</artifactId>
+				<version>${apache.maven.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-settings</artifactId>
+				<version>${apache.maven.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-compat</artifactId>
+				<version>${apache.maven.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven.shared</groupId>
+				<artifactId>maven-shared-utils</artifactId>
+				<version>3.4.2</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven.shared</groupId>
+				<artifactId>maven-artifact-transfer</artifactId>
+				<version>0.13.1</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-server</artifactId>
+				<version>${jetty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-io</artifactId>
+				<version>${jetty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-servlet</artifactId>
+				<version>${jetty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-servlets</artifactId>
+				<version>${jetty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-client</artifactId>
+				<version>${jetty.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -202,11 +264,6 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-		<dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -365,11 +422,13 @@
 			<groupId>org.mock-server</groupId>
 			<artifactId>mockserver-junit-jupiter</artifactId>
 			<version>5.15.0</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.sonatype.sisu</groupId>
 			<artifactId>sisu-guava</artifactId>
 			<version>0.11.1</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,22 @@
 		<dependency.check.version>8.4.3</dependency.check.version>
 		<jetty.version>9.4.53.v20231009</jetty.version>
 		<apache.maven.version>3.9.6</apache.maven.version>
+		<eclipse.collections.version>11.1.0</eclipse.collections.version>
+		<junit.jupiter.version>5.10.1</junit.jupiter.version>
+		<maven.shared.utils.version>3.4.2</maven.shared.utils.version>
+		<maven.artifact.transfer.version>0.13.1</maven.artifact.transfer.version>
+		<httpclient.osgi.version>4.5.14</httpclient.osgi.version>
+		<commons.logging.version>1.2</commons.logging.version>
+		<junit.version>4.13.2</junit.version>
+		<json.version>20231013</json.version>
+		<mockserver.junit.jupiter.version>5.15.0</mockserver.junit.jupiter.version>
+		<sisu.guava.version>0.11.1</sisu.guava.version>
+		<apache.maven.plugins.version>3.1.1</apache.maven.plugins.version>
+		<maven.release.plugin.version>2.5.3</maven.release.plugin.version>
+		<maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
+		<maven.shade.plugin.version>3.0.0</maven.shade.plugin.version>
+		<maven.surefire.plugin.version>3.0.0-M3</maven.surefire.plugin.version>
+
 		<docker.maven.version>0.40.2</docker.maven.version>
 		<dockerImageTag>${project.version}</dockerImageTag>
 
@@ -40,7 +56,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>${maven.compiler.plugin.version}</version>
 				<configuration>
 					<source>${java.level}</source>
 					<target>${java.level}</target>
@@ -50,7 +66,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>${maven.shade.plugin.version}</version>
 				<configuration>
 					<artifactSet>
 						<includes>
@@ -83,7 +99,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0-M3</version>
+				<version>${maven.surefire.plugin.version}</version>
 				<configuration>
 					<argLine>${argLine} ${extraArgLine}</argLine>
 				</configuration>
@@ -92,7 +108,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>2.5.3</version>
+				<version>${maven.release.plugin.version}</version>
 				<configuration>
 					<tagNameFormat>@{project.version}</tagNameFormat>
 					<arguments>-Dmaven.javadoc.skip=true</arguments>
@@ -102,7 +118,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>3.1.1</version>
+				<version>${apache.maven.plugins.version}</version>
 				<configuration>
 					<finalName>${project.artifactId}</finalName>
 					<descriptors>
@@ -123,7 +139,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.1.1</version>
+				<version>${apache.maven.plugins.version}</version>
 			</plugin>
 			<plugin>
 				<groupId>org.owasp</groupId>
@@ -208,12 +224,12 @@
 			<dependency>
 				<groupId>org.apache.maven.shared</groupId>
 				<artifactId>maven-shared-utils</artifactId>
-				<version>3.4.2</version>
+				<version>${maven.shared.utils.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven.shared</groupId>
 				<artifactId>maven-artifact-transfer</artifactId>
-				<version>0.13.1</version>
+				<version>${maven.artifact.transfer.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.jetty</groupId>
@@ -252,7 +268,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient-osgi</artifactId>
-			<version>4.5.13</version>
+			<version>${httpclient.osgi.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
@@ -304,7 +320,7 @@
 		<dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.1.1</version>
+            <version>${commons.logging.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
@@ -375,13 +391,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.7.2</version>
+            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
 		<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
@@ -403,31 +419,29 @@
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
-            <version>11.0.0.M2</version>
-<!--            <scope>provided</scope>-->
+            <version>${eclipse.collections.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
-            <version>11.0.0.M2</version>
-<!--            <scope>provided</scope>-->
+            <version>${eclipse.collections.version}</version>
         </dependency>
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
-			<version>20231013</version>
+			<version>${json.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mock-server</groupId>
 			<artifactId>mockserver-junit-jupiter</artifactId>
-			<version>5.15.0</version>
+			<version>${mockserver.junit.jupiter.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.sonatype.sisu</groupId>
 			<artifactId>sisu-guava</artifactId>
-			<version>0.11.1</version>
+			<version>${sisu.guava.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -471,7 +485,7 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-surefire-plugin</artifactId>
-							<version>3.0.0-M3</version>
+							<version>${maven.surefire.plugin.version}</version>
 							<configuration>
 								<jvm>${test.java}/bin/java</jvm>
 							</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -9,16 +9,16 @@
 	<description>Kafka Sink Connector for RDF update streaming to GraphDB</description>
 
 	<properties>
-		<graphdb.version>10.0.0-RDF4J4-BOOTSTRAP1</graphdb.version>
-        <kafka.version>2.8.0</kafka.version>
-		<slf4j.version>1.7.30</slf4j.version>
+		<graphdb.version>10.5.0</graphdb.version>
+        <kafka.version>3.5.2</kafka.version>
+		<slf4j.version>1.7.36</slf4j.version>
         <jackson.version>2.10.1</jackson.version>
         <java.level>11</java.level>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <confluent.serializer.version>5.3.2</confluent.serializer.version>
-		<rdf4j.version>3.7.2</rdf4j.version>
-		<confluent.connect.plugin.version>0.11.1</confluent.connect.plugin.version>
-        <avro.version>1.9.1</avro.version>
+        <confluent.serializer.version>7.5.3</confluent.serializer.version>
+		<rdf4j.version>4.3.8</rdf4j.version>
+		<confluent.connect.plugin.version>0.12.0</confluent.connect.plugin.version>
+        <avro.version>1.11.3</avro.version>
 		<dependency.check.version>7.4.4</dependency.check.version>
 		<docker.maven.version>0.40.2</docker.maven.version>
 		<dockerImageTag>${project.version}</dockerImageTag>
@@ -227,22 +227,22 @@
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-http-client</artifactId>
-            <version>3.7.2</version>
+            <version>${rdf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-repository-http</artifactId>
-            <version>3.7.2</version>
+            <version>${rdf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-repository-manager</artifactId>
-            <version>3.7.2</version>
+            <version>${rdf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-repository-sail</artifactId>
-            <version>3.7.2</version>
+            <version>${rdf4j.version}</version>
         </dependency>
 		<dependency>
             <groupId>commons-logging</groupId>
@@ -324,7 +324,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
 		<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
@@ -359,12 +359,12 @@
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
-			<version>20210307</version>
+			<version>20231013</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mock-server</groupId>
 			<artifactId>mockserver-junit-jupiter</artifactId>
-			<version>5.11.2</version>
+			<version>5.15.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.sonatype.sisu</groupId>

--- a/src/main/java/com/ontotext/kafka/operation/GraphDBOperator.java
+++ b/src/main/java/com/ontotext/kafka/operation/GraphDBOperator.java
@@ -32,8 +32,7 @@ public class GraphDBOperator extends RetryWithToleranceOperator implements Opera
 
 	public GraphDBOperator(Map<String, ?> properties) {
 		super((Long) properties.get(ConnectorConfig.ERRORS_RETRY_TIMEOUT_CONFIG),
-			(Long) properties.get(ConnectorConfig.ERRORS_RETRY_MAX_DELAY_CONFIG), getTolerance(properties), new SystemTime());
-		metrics(METRICS);
+			(Long) properties.get(ConnectorConfig.ERRORS_RETRY_MAX_DELAY_CONFIG), getTolerance(properties), new SystemTime(), METRICS);
 		errorRetryTimeout = (Long) properties.get(ConnectorConfig.ERRORS_RETRY_TIMEOUT_CONFIG);
 		errorMaxDelayInMillis = (Long) properties.get(ConnectorConfig.ERRORS_RETRY_MAX_DELAY_CONFIG);
 		tolerance = getTolerance(properties);

--- a/src/main/java/com/ontotext/kafka/producer/GraphDBProducer.java
+++ b/src/main/java/com/ontotext/kafka/producer/GraphDBProducer.java
@@ -92,7 +92,7 @@ public class GraphDBProducer<K,V> extends KafkaProducer<K,V>{
 
                 ByteArrayOutputStream message = new ByteArrayOutputStream();
 
-                try (GraphQueryResult res = QueryResults.parseGraphBackground(dataStream,dataFile, inputFormat);
+                try (GraphQueryResult res = QueryResults.parseGraphBackground(dataStream, dataFile, inputFormat, null);
                     BufferedReader keysReader = new BufferedReader(new FileReader(keysFile))) {
                     String keyLine = keysReader.readLine();
                     String keyName = keyLine.split("=")[1];

--- a/src/test/java/com/ontotext/kafka/mocks/DummyRepository.java
+++ b/src/test/java/com/ontotext/kafka/mocks/DummyRepository.java
@@ -40,10 +40,6 @@ public class DummyRepository implements Repository {
 	}
 
 	@Override
-	public void initialize() throws RepositoryException {
-	}
-
-	@Override
 	public void init() throws RepositoryException {
 	}
 

--- a/src/test/java/com/ontotext/kafka/mocks/DummyRepositoryConnection.java
+++ b/src/test/java/com/ontotext/kafka/mocks/DummyRepositoryConnection.java
@@ -1,6 +1,6 @@
 package com.ontotext.kafka.mocks;
 
-import org.eclipse.rdf4j.IsolationLevel;
+import org.eclipse.rdf4j.common.transaction.IsolationLevel;
 import org.eclipse.rdf4j.common.iteration.Iteration;
 import org.eclipse.rdf4j.http.client.query.AbstractHTTPUpdate;
 import org.eclipse.rdf4j.model.*;


### PR DESCRIPTION
Upgraded kafka versions to 3.5.2, which are the versions compatible with confluent 7.5.x. Also upgrade the version of RDF4J, confluent connect, GDB and avro to latest versions.