### PR TITLE
GDB-9300 Added brief description in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,33 @@
 # kafka-sink-graphdb
 Kafka Sink Connector for RDF update streaming to GraphDB
 
+The current version of Apache Kafka in project is 3.5.x.
+
+Apache Kafka 3.5.x is compatible with Confluent Platform version 7.5.x.
+
+This means you can leverage the latest enhancements in both Apache Kafka and Confluent Platform to enhance the performance,
+
+scalability, and features of your streaming applications.
+
+## Upgrading Kafka Version
+
+When upgrading your Apache Kafka installation, it's crucial to ensure compatibility between Confluent and Apache Kafka versions.
+
+Follow the guidelines provided by the Confluent documentation to guarantee a smooth upgrade process.
+
+Ensure that you refer to the compatibility matrix to find the suitable Confluent Platform version for your desired Apache Kafka version. The matrix can be found at the following link:
+
+[Confluent Platform and Apache Kafka Compatibility Matrix](https://docs.confluent.io/platform/current/installation/versions-interoperability.html#cp-and-apache-ak-compatibility)
+
+Follow these steps to upgrade your Kafka installation:
+
+1. Review the compatibility matrix to identify the Confluent Platform version that matches your target Apache Kafka version.
+2. Follow the upgrade instructions provided by Confluent for the chosen Confluent Platform version.
+
+It's recommended to perform thorough testing in a staging environment before applying the upgrade to your production environment.
+
+For detailed instructions and additional information, consult the official Confluent documentation.
+
 # Docker & Docker Compose
 
 A [Dockerfile](./Dockerfile) is available for building the sink connector as a docker image.


### PR DESCRIPTION
Added brief description in README.md file about the current  Apache Kafka version and which Confluent versions it is compatible with. Also added reference to the compatibility matrix for future kafka version update.