### PR TITLE
GDB-9392 Added logic that gets provided security configurations to the kafka-sink and pass them to the FailedRecordProducer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,21 +59,19 @@ select * where {
 }
 ```
 
-# Secured Kafka Sink with FailedRecordProducer Configuration
+# Enable Security for Failed Messages sent to DLQ
 
-This guide provides instructions on how to start a secured Kafka Sink while configuring
+This guide offers step-by-step instructions for initiating a secure Kafka Sink configuration, incorporating security properties.
 
-the inner FailedRecordProducer with security properties. The configuration can be provided
-
-either using properties with a "producer.override." prefix or through environment variables in the Dockerfile.
+The configuration details can be specified using properties prefixed with "producer.override." or through environment variables in the Dockerfile.
 
 ## Configuration Options
 
-### Using "producer.override." Prefix in Properties
+### Utilizing ["producer.override."](https://docs.confluent.io/platform/current/connect/references/allconfigs.html#override-the-worker-configuration) Prefix in Property Configuration
 
-To configure the inner FailedRecordProducer with security properties using a "producer.override." prefix:
+To apply security properties, integrate the required settings into given .properties file.
 
-Provide the `graphdb-kafka-sink.properties` file to include security properties with the "producer.override." prefix. For example:
+Provide the "producer.override." prefix to indicate security-related parameters. For example:
 
 ```properties
 
@@ -238,7 +236,7 @@ services:
 		  CONNECT_CONSUMER_SSL_CLIENT_AUTH: required
 ```
 > **Note:** </br>
-> The FailedRecordProducer will initiate only if both "errors.tolerance": "all" and a value for "errors.deadletterqueue.topic.name"</br>
+> The DLQ (Dead Letter Queue) producer will initiate only if both "errors.tolerance": "all" and a value for "errors.deadletterqueue.topic.name"</br>
 > are either specified in the properties file or passed as runtime properties.</br>
 > They cannot be provided as environment variables. </br>
 > If security configuration is not found in the properties file or as a runtime property the application </br>

--- a/README.md
+++ b/README.md
@@ -58,3 +58,188 @@ select * where {
     <urn:a> ?p ?o  .
 }
 ```
+
+# Secured Kafka Sink with FailedRecordProducer Configuration
+
+This guide provides instructions on how to start a secured Kafka Sink while configuring
+
+the inner FailedRecordProducer with security properties. The configuration can be provided
+
+either using properties with a "producer.override." prefix or through environment variables in the Dockerfile.
+
+## Configuration Options
+
+### Using "producer.override." Prefix in Properties
+
+To configure the inner FailedRecordProducer with security properties using a "producer.override." prefix:
+
+Provide the `graphdb-kafka-sink.properties` file to include security properties with the "producer.override." prefix. For example:
+
+```properties
+
+name=GraphDBSinkConnector
+connector.class=com.ontotext.kafka.GraphDBSinkConnector
+
+graphdb.server.url=Type: String;\nDescription: GraphDB Server URL
+graphdb.server.repository=Type: String;\nDescription: GraphDB Repository
+
+graphdb.batch.size=Type: Int;
+
+graphdb.auth.type=Type: enum[NONE, BASIC, CUSTOM];\nDescription: Authentication type (default NONE)
+graphdb.auth.basic.username=Type: String;
+graphdb.auth.basic.password=Type: String;
+graphdb.auth.header.token=Type: String;\nDescription: GraphDB Auth Token
+
+graphdb.update.type=Type: enum[ADD, REPLACE_GRAPH, SMART_UPDATE];\nDescription: Transaction type (default NONE)
+graphdb.update.rdf.format=Type: enum[rdf, rdfs, xml, owl, nt, ttl, ttls, n3, xml, trix, trig, trigs, brf, nq, jsonld, ndjsonld, jsonl, ndjson, rj, xhtml, html, hdt];\nDescription: Transaction type (default NONE)
+graphdb.batch.commit.limit.ms=Type: Long;\nDescription: The timeout applied per batch that is not full before it is committed (default 3000)
+
+errors.tolerance=all
+#The topic name in kafka brokers to store failed records
+errors.deadletterqueue.topic.name=failed-messages-01
+#Type:Long;\nDescription: Maximum time in ms to retry sending records
+producer.override.errors.retry.timeout=5000
+#Type:Long;\nDescription: The time in ms in-between retries
+producer.override.errors.retry.delay.max.ms=1000
+#Type:List;\nDescription: The IRIs of kafka brokers (default localhost:9092,localhost:9093,localhost:9093)
+bootstrap.servers=localhost:9092
+producer.override.errors.deadletterqueue.topic.replication.factor=1
+producer.override.bootstrap.servers=your-bootstrap-servers
+producer.override.security.protocol=SASL_SSL
+producer.override.sasl.mechanism=PLAIN
+producer.override.sasl.jaas.config=your-sasl-config
+```
+
+or pass properties runtime in config on start of the connector
+
+```shell
+	if ! curl -s --fail host:port/connectors/kafka-sink-graphdb &> /dev/null; then
+		curl -H 'Content-Type: application/json' --data '
+		{
+			"name": "kafka-sink-graphdb",
+			"config": {
+				"connector.class":"com.ontotext.kafka.GraphDBSinkConnector",
+				"key.converter": "com.ontotext.kafka.convert.DirectRDFConverter",
+				"value.converter": "com.ontotext.kafka.convert.DirectRDFConverter",
+				"value.converter.schemas.enable": "false",
+				"topics":"test",
+				"tasks.max":"1",
+				"offset.storage.file.filename": "/tmp/storage",
+				"graphdb.server.url": "http://graphdb:7200",
+				"graphdb.server.repository": "test",
+				"graphdb.batch.size": 64,
+				"graphdb.batch.commit.limit.ms": 1000,
+				"graphdb.auth.type": "NONE",
+				"graphdb.update.type": "ADD",
+				"graphdb.update.rdf.format": "nq",
+				"errors.tolerance": "all",
+				"bootstrap.servers": "localhost:9092",
+				"errors.deadletterqueue.topic.name": "failed-messages-01",
+				"producer.override.errors.retry.timeout": "5000",
+				"producer.override.errors.retry.delay.max.ms": "1000",
+				"producer.override.errors.deadletterqueue.topic.replication.factor": "1",
+				"producer.override.bootstrap.servers": "your-bootstrap-servers",
+				"producer.override.security.protocol": "SASL_SSL",
+				"producer.override.sasl.mechanism": "PLAIN",
+				"producer.override.sasl.jaas.config": "your-sasl-config"
+			}
+		}' http://host:port/connectors -w "\n"
+	fi
+```
+
+### Using Environment Variables in Dockerfile
+
+To configure the inner FailedRecordProducer with security properties using environment variables in the Dockerfile:
+
+```dockerfile
+version: '3'
+
+services:
+  connect-1:
+    image: docker-registry.ontotext.com/kafka-sink-graphdb:<your_version>
+    hostname: connect-1
+    container_name: connect-1
+    network_mode: host
+    ports:
+      - 8083:8083
+	environment:
+		  CONNECT_BOOTSTRAP_SERVERS: SSL://your_host:your_port
+		  CONNECT_REST_ADVERTISED_HOST_NAME: your_host
+		  CONNECT_REST_PORT: port
+		  CONNECT_REST_HOST_NAME: host
+		  CONNECT_GROUP_ID: compose-connect-group-id
+		  CONNECT_KEY_CONVERTER: key_serializer.class
+		  CONNECT_VALUE_CONVERTER: value_serializer.class
+		  CONNECT_INTERNAL_KEY_CONVERTER: key_converter.class
+		  CONNECT_INTERNAL_VALUE_CONVERTER: value_converter.class
+		  CONNECT_CONFIG_STORAGE_TOPIC: docker-connect-configs-topic
+		  CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: 1
+		  CONNECT_OFFSET_FLUSH_INTERVAL_MS: 10000
+		  CONNECT_OFFSET_STORAGE_TOPIC: docker-connect-offsets-storage-topic
+		  CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
+		  CONNECT_STATUS_STORAGE_TOPIC: docker-connect-status-storage-topic
+		  CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
+		  CONNECT_ZOOKEEPER_CONNECT: example.test.com:2181
+
+		  CONNECT_SASL_MECHANISM: PLAIN
+		  CONNECT_CONSUMER_SASL_MECHANISM: PLAIN
+		  CONNECT_PRODUCER_SASL_MECHANISM: PLAIN
+		  CONNECT_SASL_JAAS_CONFIG: |
+			org.apache.kafka.common.security.plain.PlainLoginModule required \
+			username="username" \
+			serviceName="servicename" \
+			password="password";
+		  CONNECT_CONSUMER_SASL_JAAS_CONFIG: |
+			org.apache.kafka.common.security.plain.PlainLoginModule required \
+			username="username" \
+			serviceName="servicename" \
+			password="password";
+		  CONNECT_PRODUCER_SASL_JAAS_CONFIG: |
+			org.apache.kafka.common.security.plain.PlainLoginModule required \
+			serviceName="servicename" \
+			username="username" \
+			password="password";
+		  CONNECT_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM: HTTPS
+
+		  CONNECT_SECURITY_PROTOCOL: SASL_SSL
+		  CONNECT_SSL_TRUSTSTORE_FILENAME: /path_to/keystore.jks
+		  CONNECT_SSL_TRUSTSTORE_LOCATION: /path_to/keystore.jks
+		  CONNECT_SSL_TRUSTSTORE_PASSWORD: changeit
+		  CONNECT_SSL_KEYSTORE_FILENAME: /path_to/keystore.jks
+		  CONNECT_SSL_KEYSTORE_LOCATION: /path_to/keystore.jks
+		  CONNECT_SSL_KEYSTORE_PASSWORD: changeit
+		  CONNECT_SSL_KEY_PASSWORD: my_password
+
+		  CONNECT_CONSUMER_SECURITY_PROTOCOL: SASL_SSL
+		  CONNECT_CONSUMER_SSL_TRUSTSTORE_LOCATION: /path_to/keystore.jks
+		  CONNECT_CONSUMER_SSL_TRUSTSTORE_PASSWORD: changeit
+		  CONNECT_CONSUMER_SSL_KEYSTORE_LOCATION: /path_to/keystore.jks
+		  CONNECT_CONSUMER_SSL_KEYSTORE_FILENAME: /path_to/keystore.jks
+		  CONNECT_CONSUMER_SSL_KEYSTORE_PASSWORD: changeit
+		  CONNECT_CONSUMER_SSL_KEY_PASSWORD: my_password
+
+		  CONNECT_PRODUCER_SECURITY_PROTOCOL: SASL_SSL
+		  CONNECT_PRODUCER_SSL_TRUSTSTORE_LOCATION: /path_to/keystore.jks
+		  CONNECT_PRODUCER_SSL_TRUSTSTORE_PASSWORD: changeit
+		  CONNECT_PRODUCER_SSL_KEYSTORE_LOCATION: /path_to/keystore.jks
+		  CONNECT_PRODUCER_SSL_KEYSTORE_FILENAME: /path_to/keystore.jks
+		  CONNECT_PRODUCER_SSL_KEYSTORE_PASSWORD: changeit
+		  CONNECT_PRODUCER_SSL_KEY_PASSWORD: my_password
+
+		  CONNECT_PRODUCER_SSL_KEYSTORE_CREDENTIALS: /path_to/kafka-cred.properties
+		  CONNECT_PRODUCER_SSL_KEY_CREDENTIALS: /path_to/kafka-cred.properties
+		  CONNECT_PRODUCER_SSL_TRUSTSTORE_CREDENTIALS: /path_to/kafka-cred.properties
+		  CONNECT_PRODUCER_SSL_TRUST_CREDENTIALS: /path_to/kafka-cred.properties
+
+		  CONNECT_CONSUMER_SSL_KEYSTORE_CREDENTIALS: /path_to/kafka-cred.properties
+		  CONNECT_CONSUMER_SSL_KEY_CREDENTIALS: /path_to/kafka-cred.properties
+		  CONNECT_CONSUMER_SSL_TRUSTSTORE_CREDENTIALS: /path_to/kafka-cred.properties
+		  CONNECT_CONSUMER_SSL_TRUST_CREDENTIALS: /path_to/kafka-cred.properties
+		  CONNECT_CONSUMER_SSL_CLIENT_AUTH: required
+```
+> **Note:** </br>
+> The FailedRecordProducer will initiate only if both "errors.tolerance": "all" and a value for "errors.deadletterqueue.topic.name"</br>
+> are either specified in the properties file or passed as runtime properties.</br>
+> They cannot be provided as environment variables. </br>
+> If security configuration is not found in the properties file or as a runtime property the application </br>
+> will provide all resolved environment properties when the kafka producer is created

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,8 @@
 		<maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
 		<maven.shade.plugin.version>3.0.0</maven.shade.plugin.version>
 		<maven.surefire.plugin.version>3.0.0-M3</maven.surefire.plugin.version>
+		<mockito.version>5.2.0</mockito.version>
+		<system-stubs-jupiter.version>2.1.3</system-stubs-jupiter.version>
 
 		<docker.maven.version>0.40.2</docker.maven.version>
 		<dockerImageTag>${project.version}</dockerImageTag>
@@ -442,6 +444,18 @@
 			<groupId>org.sonatype.sisu</groupId>
 			<artifactId>sisu-guava</artifactId>
 			<version>${sisu.guava.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>uk.org.webcompere</groupId>
+			<artifactId>system-stubs-jupiter</artifactId>
+			<version>${system-stubs-jupiter.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>${mockito.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/ontotext/kafka/error/FailedRecordProducer.java
+++ b/src/main/java/com/ontotext/kafka/error/FailedRecordProducer.java
@@ -5,7 +5,7 @@ import com.ontotext.kafka.util.ValueUtil;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.connect.runtime.SinkConnectorConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,9 +18,9 @@ class FailedRecordProducer implements FailedProducer {
 	private final String topicName;
 	private final Producer<String, String> producer;
 
-	FailedRecordProducer(Properties properties) {
-		producer = new KafkaProducer<>(properties);
-		topicName = properties.getProperty(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG);
+	FailedRecordProducer(String topicName, Properties properties) {
+		this.producer = new KafkaProducer<>(properties, new StringSerializer(), new StringSerializer());
+		this.topicName = topicName;
 	}
 
 	@VisibleForTesting

--- a/src/main/java/com/ontotext/kafka/error/LogErrorHandler.java
+++ b/src/main/java/com/ontotext/kafka/error/LogErrorHandler.java
@@ -85,8 +85,7 @@ public class LogErrorHandler implements ErrorHandler {
 		for (Map.Entry<String, String> entry : envVars.entrySet()) {
 			var key = entry.getKey();
 			if (key.startsWith(CONNECT_ENV_PREFIX)) {
-				key = key.replaceFirst("^CONNECT_CONSUMER_", "")
-					.replaceFirst("^CONNECT_PRODUCER_", "")
+				key = key.replaceFirst("^CONNECT_PRODUCER_", "")
 					.replaceFirst("^" + CONNECT_ENV_PREFIX, "").replace("_", ".").toLowerCase();
 				var entryValue = entry.getValue();
 				props.put(key, escapeNewLinesFromString(entryValue));

--- a/src/main/java/com/ontotext/kafka/error/LogErrorHandler.java
+++ b/src/main/java/com/ontotext/kafka/error/LogErrorHandler.java
@@ -68,9 +68,9 @@ public class LogErrorHandler implements ErrorHandler {
 
 	private Properties getProperties(Map<String, ?> properties) {
 		Properties props = new Properties();
-		if (!resolveProducerProperties(properties, props)) {
-			resolvePropertiesFromEnvironment(props);
-		}
+		resolveProducerProperties(properties, props);
+		resolvePropertiesFromEnvironment(props);
+
 		props.put(ProducerConfig.CLIENT_ID_CONFIG, FailedRecordProducer.class.getSimpleName());
 		return props;
 	}
@@ -93,22 +93,17 @@ public class LogErrorHandler implements ErrorHandler {
 		}
 	}
 
-	private boolean resolveProducerProperties(Map<String, ?> properties, Properties props) {
-		boolean producerPropertiesResolvedFromPassed = false;
+	private void resolveProducerProperties(Map<String, ?> properties, Properties props) {
 		for (Map.Entry<String, ?> entry : properties.entrySet()) {
 			var key = entry.getKey();
 			if (key.startsWith(PRODUCER_OVERRIDE_PREFIX)) {
-				producerPropertiesResolvedFromPassed = true;
 				props.put(key.substring(PRODUCER_OVERRIDE_PREFIX.length()), entry.getValue());
 			}
 		}
-		if (producerPropertiesResolvedFromPassed) {
-			var bootstrapServers = properties.get(BOOTSTRAP_SERVERS_CONFIG);
-			if (StringUtils.isNotEmpty((String) bootstrapServers)) {
-				props.put(BOOTSTRAP_SERVERS_CONFIG, properties.get(BOOTSTRAP_SERVERS_CONFIG));
-			}
+		var bootstrapServers = properties.get(BOOTSTRAP_SERVERS_CONFIG);
+		if (StringUtils.isNotEmpty((String) bootstrapServers)) {
+			props.put(BOOTSTRAP_SERVERS_CONFIG, properties.get(BOOTSTRAP_SERVERS_CONFIG));
 		}
-		return producerPropertiesResolvedFromPassed;
 	}
 
 	@VisibleForTesting

--- a/src/test/java/com/ontotext/kafka/error/LogErrorHandlerTest.java
+++ b/src/test/java/com/ontotext/kafka/error/LogErrorHandlerTest.java
@@ -2,7 +2,8 @@ package com.ontotext.kafka.error;
 
 import static com.ontotext.kafka.GraphDBSinkConfig.SERVER_IRI;
 import static com.ontotext.kafka.error.LogErrorHandler.CONNECT_ENV_PREFIX;
-import static com.ontotext.kafka.error.LogErrorHandler.PRODUCER_OVERRIDE_PROPERTY;
+import static com.ontotext.kafka.error.LogErrorHandler.PRODUCER_OVERRIDE_PREFIX;
+import static com.ontotext.kafka.error.LogErrorHandler.escapeNewLinesFromString;
 import static java.util.Map.entry;
 import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;
@@ -16,9 +17,7 @@ import static org.apache.kafka.connect.runtime.ConnectorConfig.ERRORS_TOLERANCE_
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -88,12 +87,12 @@ class LogErrorHandlerTest {
 			SERVER_IRI, "http://localhost:7200",
 			DLQ_TOPIC_NAME_CONFIG, "error_topic",
 			BOOTSTRAP_SERVERS_CONFIG, "localhost:9092",
-			PRODUCER_OVERRIDE_PROPERTY + SSL_KEY_PASSWORD_CONFIG, new Password("my_pass"),
-			PRODUCER_OVERRIDE_PROPERTY + SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, new Password("my_pass"),
-			PRODUCER_OVERRIDE_PROPERTY + SSL_KEYSTORE_KEY_CONFIG, new Password("my_pass"),
-			PRODUCER_OVERRIDE_PROPERTY + SSL_KEYSTORE_LOCATION_CONFIG, "/keystore_resource_file_path",
-			PRODUCER_OVERRIDE_PROPERTY + SSL_ENGINE_FACTORY_CLASS_CONFIG, LogErrorHandlerTest.class,
-			PRODUCER_OVERRIDE_PROPERTY + SSL_PROVIDER_CONFIG, "/path_to_ssl_provider_config");
+			PRODUCER_OVERRIDE_PREFIX + SSL_KEY_PASSWORD_CONFIG, new Password("my_pass"),
+			PRODUCER_OVERRIDE_PREFIX + SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, new Password("my_pass"),
+			PRODUCER_OVERRIDE_PREFIX + SSL_KEYSTORE_KEY_CONFIG, new Password("my_pass"),
+			PRODUCER_OVERRIDE_PREFIX + SSL_KEYSTORE_LOCATION_CONFIG, "/keystore_resource_file_path",
+			PRODUCER_OVERRIDE_PREFIX + SSL_ENGINE_FACTORY_CLASS_CONFIG, LogErrorHandlerTest.class,
+			PRODUCER_OVERRIDE_PREFIX + SSL_PROVIDER_CONFIG, "/path_to_ssl_provider_config");
 		var mockedLockHandler = mock(LogErrorHandler.class);
 		Method getProperties = mockedLockHandler.getClass().getDeclaredMethod("getProperties", Map.class);
 		getProperties.setAccessible(true);
@@ -112,7 +111,7 @@ class LogErrorHandlerTest {
 				}
 				continue;
 			}
-			var keyWithPrefix = PRODUCER_OVERRIDE_PROPERTY + entryKey;
+			var keyWithPrefix = PRODUCER_OVERRIDE_PREFIX + entryKey;
 			assertTrue(kafkaConnectProps.containsKey(keyWithPrefix));
 			assertEquals(kafkaConnectProps.get(keyWithPrefix), entryValue);
 		}
@@ -124,7 +123,6 @@ class LogErrorHandlerTest {
 			SERVER_IRI, "http://localhost:7200",
 			DLQ_TOPIC_NAME_CONFIG, "error_topic");
 		var mockedLockHandler = mock(LogErrorHandler.class);
-		when(mockedLockHandler.escapeNewLinesFromString(anyString())).thenCallRealMethod();
 		Method getProperties = mockedLockHandler.getClass().getDeclaredMethod("getProperties", Map.class);
 		getProperties.setAccessible(true);
 		var convertedProps = (Properties) getProperties.invoke(mockedLockHandler, kafkaConnectProps);
@@ -143,7 +141,7 @@ class LogErrorHandlerTest {
 			}
 			var keyWithPrefix = CONNECT_ENV_PREFIX + (entryKey.replace(".", "_").toUpperCase());
 			assertTrue(ENV_VARIABLES.containsKey(keyWithPrefix));
-			assertEquals(mockedLockHandler.escapeNewLinesFromString((String) ENV_VARIABLES.get(keyWithPrefix)), entryValue);
+			assertEquals(escapeNewLinesFromString((String) ENV_VARIABLES.get(keyWithPrefix)), entryValue);
 		}
 	}
 }

--- a/src/test/java/com/ontotext/kafka/error/LogErrorHandlerTest.java
+++ b/src/test/java/com/ontotext/kafka/error/LogErrorHandlerTest.java
@@ -1,0 +1,149 @@
+package com.ontotext.kafka.error;
+
+import static com.ontotext.kafka.GraphDBSinkConfig.SERVER_IRI;
+import static com.ontotext.kafka.error.LogErrorHandler.CONNECT_ENV_PREFIX;
+import static com.ontotext.kafka.error.LogErrorHandler.PRODUCER_OVERRIDE_PROPERTY;
+import static java.util.Map.entry;
+import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_KEY_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_KEY_PASSWORD_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_PROVIDER_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.ERRORS_TOLERANCE_CONFIG;
+import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.kafka.common.config.types.Password;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+@ExtendWith(SystemStubsExtension.class)
+class LogErrorHandlerTest {
+	@SystemStub
+	private EnvironmentVariables environmentVariables;
+
+	private static final Map<Object, Object> ENV_VARIABLES = Map.ofEntries(entry("CONNECT_BOOTSTRAP_SERVERS", "SSL://example.test.com:9094"),
+		entry("CONNECT_REST_ADVERTISED_HOST_NAME", "example.test.com"),
+		entry("CONNECT_REST_PORT", "8083"),
+		entry("CONNECT_REST_HOST_NAME", "example.test.com"),
+		entry("CONNECT_GROUP_ID", "compose-connect-group-1"),
+		entry("CONNECT_KEY_CONVERTER", "org.apache.kafka.connect.converters.ByteArrayConverter"),
+		entry("CONNECT_VALUE_CONVERTER", "org.apache.kafka.connect.converters.ByteArrayConverter"),
+		entry("CONNECT_INTERNAL_KEY_CONVERTER", "org.apache.kafka.connect.json.JsonConverter"),
+		entry("CONNECT_INTERNAL_VALUE_CONVERTER", "org.apache.kafka.connect.json.JsonConverter"),
+		entry("CONNECT_CONFIG_STORAGE_TOPIC", "docker-connect-configs-1"),
+		entry("CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR", "1"),
+		entry("CONNECT_OFFSET_FLUSH_INTERVAL_MS", "10000"),
+		entry("CONNECT_OFFSET_STORAGE_TOPIC", "docker-connect-offsets-1"),
+		entry("CONNECT_SASL_MECHANISM", "PLAIN"),
+		entry("CONNECT_CONSUMER_SASL_MECHANISM", "PLAIN"),
+		entry("CONNECT_PRODUCER_SASL_MECHANISM", "PLAIN"),
+		entry("CONNECT_SASL_JAAS_CONFIG",
+			"        org.apache.kafka.common.security.plain.PlainLoginModule required \\\n" +
+			"        username=\"fester\" \\\n" +
+			"        serviceName=\"kafka\" \\\n" +
+			"        password=\"festerpass\";"),
+		entry("CONNECT_CONSUMER_SASL_JAAS_CONFIG",
+			"        org.apache.kafka.common.security.plain.PlainLoginModule required \\\n" +
+			"        username=\"fester\" \\\n" +
+			"        serviceName=\"kafka\" \\\n" +
+			"        password=\"festerpass\";"),
+		entry("CONNECT_PRODUCER_SASL_JAAS_CONFIG",
+			"        org.apache.kafka.common.security.plain.PlainLoginModule required \\\n" +
+			"        username=\"fester\" \\\n" +
+			"        serviceName=\"kafka\" \\\n" +
+			"        password=\"festerpass\";"),
+		entry("CONNECT_SECURITY_PROTOCOL", "SASL_SSL"),
+		entry("CONNECT_SSL_TRUSTSTORE_LOCATION", "/etc/kafka/secrets/keystore7200.jks"),
+		entry("CONNECT_CONSUMER_SSL_TRUSTSTORE_LOCATION", "/etc/kafka/secrets/keystore7200.jks"),
+		entry("CONNECT_PRODUCER_SSL_TRUSTSTORE_LOCATION", "/etc/kafka/secrets/keystore7200.jks"),
+		entry("CONNECT_SSL_KEY_PASSWORD", "192.168.129.24-node-7200pass"),
+		entry("CONNECT_CONSUMER_SSL_KEY_PASSWORD", "192.168.129.24-node-7200pass"),
+		entry("CONNECT_PRODUCER_SSL_KEY_PASSWORD", "192.168.129.24-node-7200pass"));
+
+	@BeforeEach
+	void beforeEach() {
+		environmentVariables.set(ENV_VARIABLES);
+	}
+
+	@Test
+	void testFailedRecordProducerConfiguration() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+		var kafkaConnectProps = Map.of(ERRORS_TOLERANCE_CONFIG, "all",
+			SERVER_IRI, "http://localhost:7200",
+			DLQ_TOPIC_NAME_CONFIG, "error_topic",
+			BOOTSTRAP_SERVERS_CONFIG, "localhost:9092",
+			PRODUCER_OVERRIDE_PROPERTY + SSL_KEY_PASSWORD_CONFIG, new Password("my_pass"),
+			PRODUCER_OVERRIDE_PROPERTY + SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, new Password("my_pass"),
+			PRODUCER_OVERRIDE_PROPERTY + SSL_KEYSTORE_KEY_CONFIG, new Password("my_pass"),
+			PRODUCER_OVERRIDE_PROPERTY + SSL_KEYSTORE_LOCATION_CONFIG, "/keystore_resource_file_path",
+			PRODUCER_OVERRIDE_PROPERTY + SSL_ENGINE_FACTORY_CLASS_CONFIG, LogErrorHandlerTest.class,
+			PRODUCER_OVERRIDE_PROPERTY + SSL_PROVIDER_CONFIG, "/path_to_ssl_provider_config");
+		var mockedLockHandler = mock(LogErrorHandler.class);
+		Method getProperties = mockedLockHandler.getClass().getDeclaredMethod("getProperties", Map.class);
+		getProperties.setAccessible(true);
+		var convertedProps = (Properties) getProperties.invoke(mockedLockHandler, kafkaConnectProps);
+		for (var entry : convertedProps.entrySet()) {
+			var entryKey = entry.getKey();
+			var entryValue = entry.getValue();
+			if (ERRORS_TOLERANCE_CONFIG.equals(entryKey)
+				|| DLQ_TOPIC_NAME_CONFIG.equals(entryKey)
+				|| BOOTSTRAP_SERVERS_CONFIG.equals(entryKey)
+				|| SERVER_IRI.equals(entryKey)
+				|| CLIENT_ID_CONFIG.equals(entryKey)) {
+				if (!CLIENT_ID_CONFIG.equals(entryKey)) {
+					assertTrue(kafkaConnectProps.containsKey(entryKey));
+					assertEquals(kafkaConnectProps.get(entryKey), entryValue);
+				}
+				continue;
+			}
+			var keyWithPrefix = PRODUCER_OVERRIDE_PROPERTY + entryKey;
+			assertTrue(kafkaConnectProps.containsKey(keyWithPrefix));
+			assertEquals(kafkaConnectProps.get(keyWithPrefix), entryValue);
+		}
+	}
+
+	@Test
+	void testFailedRecordProducerConfigurationFromEnvironmentVariables() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+		var kafkaConnectProps = Map.of(ERRORS_TOLERANCE_CONFIG, "all",
+			SERVER_IRI, "http://localhost:7200",
+			DLQ_TOPIC_NAME_CONFIG, "error_topic");
+		var mockedLockHandler = mock(LogErrorHandler.class);
+		when(mockedLockHandler.escapeNewLinesFromString(anyString())).thenCallRealMethod();
+		Method getProperties = mockedLockHandler.getClass().getDeclaredMethod("getProperties", Map.class);
+		getProperties.setAccessible(true);
+		var convertedProps = (Properties) getProperties.invoke(mockedLockHandler, kafkaConnectProps);
+		for (var entry : convertedProps.entrySet()) {
+			var entryKey = (String) entry.getKey();
+			var entryValue = entry.getValue();
+			if (ERRORS_TOLERANCE_CONFIG.equals(entryKey)
+				|| DLQ_TOPIC_NAME_CONFIG.equals(entryKey)
+				|| SERVER_IRI.equals(entryKey)
+				|| CLIENT_ID_CONFIG.equals(entryKey)) {
+				if (!CLIENT_ID_CONFIG.equals(entryKey)) {
+					assertTrue(kafkaConnectProps.containsKey(entryKey));
+					assertEquals(kafkaConnectProps.get(entryKey), entryValue);
+				}
+				continue;
+			}
+			var keyWithPrefix = CONNECT_ENV_PREFIX + (entryKey.replace(".", "_").toUpperCase());
+			assertTrue(ENV_VARIABLES.containsKey(keyWithPrefix));
+			assertEquals(mockedLockHandler.escapeNewLinesFromString((String) ENV_VARIABLES.get(keyWithPrefix)), entryValue);
+		}
+	}
+}


### PR DESCRIPTION

Added tests that verify proper handling and also added a brief explanation in the README.md.