### PR TITLE
GDB-11116 concurrent kafka sink usage might lead to excess record ingestion

### DIFF
--- a/src/main/java/com/ontotext/kafka/service/SinkRecordsProcessor.java
+++ b/src/main/java/com/ontotext/kafka/service/SinkRecordsProcessor.java
@@ -36,7 +36,7 @@ public abstract class SinkRecordsProcessor implements Runnable, Operation<Object
 	private static final Object SUCCESSES = new Object();
 
 	protected final Queue<Collection<SinkRecord>> sinkRecords;
-	protected final ConcurrentLinkedQueue<SinkRecord> recordsBatch;
+	protected final Queue<SinkRecord> recordsBatch;
 	protected final Repository repository;
 	protected final AtomicBoolean shouldRun;
 	protected final RDFFormat format;


### PR DESCRIPTION
In order for our Kafka Sink code to be thread safe only one thread should be able to consume and flush records at a time which is not the case. Added lock in the consumeRecords method so no thread can add records while another thread is flushing them.