### PR TITLE
GDB-10700 Updated record handling behaviour

### DIFF
--- a/src/main/java/com/ontotext/kafka/service/SinkRecordsProcessor.java
+++ b/src/main/java/com/ontotext/kafka/service/SinkRecordsProcessor.java
@@ -157,8 +157,7 @@ public abstract class SinkRecordsProcessor implements Runnable, Operation<Object
 			LOG.trace(
 				"Transaction started in GraphDB Repository connection {} , Batch size: {} , Records in current batch: {}",
 				this.repositoryUrl, batchSize, recordsInCurrentBatch);
-			while (!recordsBatch.isEmpty()) {
-				SinkRecord record = recordsBatch.remove();
+			for (SinkRecord record : recordsBatch) {
 				if (!failedRecords.contains(record)) {
 					handleRecord(record, connection);
 				}
@@ -168,6 +167,7 @@ public abstract class SinkRecordsProcessor implements Runnable, Operation<Object
 				"Transaction in GraphDB repository connection {} commited, Batch size: {} , Records in current batch: {}",
 				this.repositoryUrl, batchSize, recordsInCurrentBatch);
 			LOG.debug("Cleared {} failed records.", failedRecords.size());
+			recordsBatch.clear();
 			failedRecords.clear();
 			if (LOG.isTraceEnabled()) {
 				long finish = System.currentTimeMillis();

--- a/src/main/java/com/ontotext/kafka/service/SinkRecordsProcessor.java
+++ b/src/main/java/com/ontotext/kafka/service/SinkRecordsProcessor.java
@@ -83,15 +83,17 @@ public abstract class SinkRecordsProcessor implements Runnable, Operation<Object
 		try {
 			commitTimer.schedule(scheduleCommitter, timeoutCommitMs, timeoutCommitMs);
 			while (shouldRun.get()) {
-				Collection<SinkRecord> messages = sinkRecords.poll();
+				Collection<SinkRecord> messages = sinkRecords.peek();
 				if (messages != null) {
 					consumeRecords(messages);
+					sinkRecords.poll();
 				}
 			}
 			// commit any records left before shutdown
 			LOG.info("Commiting any records left before shutdown");
 			while (sinkRecords.peek() != null) {
-				consumeRecords(sinkRecords.poll());
+				consumeRecords(sinkRecords.peek());
+				sinkRecords.poll();
 			}
 			// final flush after all messages have been batched
 			flushUpdates();

--- a/src/test/java/com/ontotext/kafka/service/AddRecordsProcessorTest.java
+++ b/src/test/java/com/ontotext/kafka/service/AddRecordsProcessorTest.java
@@ -250,7 +250,7 @@ class AddRecordsProcessorTest {
 	@Timeout(5)
 	void testHandleIOException() throws InterruptedException, IOException {
 		int batch = 4;
-		int expectedSize = 3;
+		int expectedSize = 4;
 
 		repository = initThrowingRepository(streams, formats, new IOException());
 		generateSinkRecords(sinkRecords, 4, 12);
@@ -290,7 +290,7 @@ class AddRecordsProcessorTest {
 	@Timeout(5)
 	void testHandleMultipleIOException() throws InterruptedException, IOException {
 		int batch = 4;
-		int expectedSize = 1;
+		int expectedSize = 4;
 
 		repository = initThrowingRepository(streams, formats, new IOException(), 3);
 		generateSinkRecords(sinkRecords, 4, 12);

--- a/src/test/java/com/ontotext/kafka/service/UpdateRecordsProcessorTest.java
+++ b/src/test/java/com/ontotext/kafka/service/UpdateRecordsProcessorTest.java
@@ -51,12 +51,6 @@ public class UpdateRecordsProcessorTest {
 		Thread recordsProcessor = createProcessorThread(sinkRecords, shouldRun, repository, batch, 5000);
 		recordsProcessor.start();
 		awaitEmptyCollection(sinkRecords);
-		assertTrue(formats.isEmpty());
-		assertTrue(streams.isEmpty());
-		shouldRun.set(false);
-		awaitProcessorShutdown(recordsProcessor);
-
-		assertFalse(recordsProcessor.isAlive());
 		assertEquals(3, streams.size());
 		for (Reader reader : streams) {
 			assertEquals(15, Rio.parse(reader, RDFFormat.NQUADS).size());
@@ -76,13 +70,6 @@ public class UpdateRecordsProcessorTest {
 		Thread recordsProcessor = createProcessorThread(sinkRecords, shouldRun, repository, batch, 5000);
 		recordsProcessor.start();
 		awaitEmptyCollection(sinkRecords);
-
-		assertTrue(formats.isEmpty());
-		assertTrue(streams.isEmpty());
-		shouldRun.set(false);
-		awaitProcessorShutdown(recordsProcessor);
-		assertFalse(recordsProcessor.isAlive());
-
 		assertEquals(3, streams.size());
 		for (Reader reader : streams) {
 			assertEquals(15, Rio.parse(reader, RDFFormat.NQUADS).size());


### PR DESCRIPTION
Updated the SinkRecordsProcessor class methods to make sure that records are handled before being removed from the sinkRecords collection so no records are lost in case of GraphDB shutdown.