### PR TITLE
Enhance smart update

### DIFF
--- a/src/main/java/com/ontotext/kafka/GraphDBSinkConfig.java
+++ b/src/main/java/com/ontotext/kafka/GraphDBSinkConfig.java
@@ -1,7 +1,7 @@
 package com.ontotext.kafka;
 
-import com.ontotext.kafka.util.ValidateEnum;
-import com.ontotext.kafka.util.ValidateRDFFormat;
+import com.ontotext.kafka.util.EnumValidator;
+import com.ontotext.kafka.util.RDFFormatValidator;
 import com.ontotext.kafka.util.ValueUtil;
 import com.ontotext.kafka.util.VisibleIfRecommender;
 import org.apache.kafka.clients.CommonClientConfigs;
@@ -163,7 +163,7 @@ public class GraphDBSinkConfig extends AbstractConfig {
 				RDF_FORMAT,
 				ConfigDef.Type.STRING,
 				DEFAULT_RDF_TYPE,
-				new ValidateRDFFormat(),
+				new RDFFormatValidator(),
 				ConfigDef.Importance.HIGH,
 				RDF_FORMAT_DOC
 			)
@@ -171,7 +171,7 @@ public class GraphDBSinkConfig extends AbstractConfig {
 				TRANSACTION_TYPE,
 				ConfigDef.Type.STRING,
 				DEFAULT_TRANSACTION_TYPE,
-				new ValidateEnum(TransactionType.class),
+				new EnumValidator(TransactionType.class),
 				ConfigDef.Importance.HIGH,
 				TRANSACTION_TYPE_DOC
 			)
@@ -200,7 +200,7 @@ public class GraphDBSinkConfig extends AbstractConfig {
 				AUTH_TYPE,
 				ConfigDef.Type.STRING,
 				DEFAULT_AUTH_TYPE,
-				new ValidateEnum(AuthenticationType.class),
+				new EnumValidator(AuthenticationType.class),
 				ConfigDef.Importance.HIGH,
 				AUTH_TYPE_DOC
 			)

--- a/src/main/java/com/ontotext/kafka/GraphDBSinkConnector.java
+++ b/src/main/java/com/ontotext/kafka/GraphDBSinkConnector.java
@@ -16,7 +16,7 @@
 
 package com.ontotext.kafka;
 
-import com.ontotext.kafka.util.ValidateGraphDBConnection;
+import com.ontotext.kafka.util.GraphDBConnectionValidator;
 import com.ontotext.kafka.util.VersionUtil;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
@@ -78,10 +78,10 @@ public class GraphDBSinkConnector extends SinkConnector {
 
 	@Override
 	public Config validate(final Map<String, String> connectorConfigs) {
-		var config = super.validate(connectorConfigs);
+		Config config = super.validate(connectorConfigs);
 		if (config.configValues().stream().anyMatch(cv -> !cv.errorMessages().isEmpty())) {
 			return config;
 		}
-		return ValidateGraphDBConnection.validateGraphDBConnection(config);
+		return GraphDBConnectionValidator.validateGraphDBConnection(config);
 	}
 }

--- a/src/main/java/com/ontotext/kafka/convert/JsonDataConverter.java
+++ b/src/main/java/com/ontotext/kafka/convert/JsonDataConverter.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.core.exc.StreamReadException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DatabindException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.collections4.CollectionUtils;
 import org.eclipse.rdf4j.rio.RDFFormat;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Map;
 
 public final class JsonDataConverter extends RdfFormatConverter {
@@ -18,6 +20,7 @@ public final class JsonDataConverter extends RdfFormatConverter {
 		this.objectMapper = new ObjectMapper();
 	}
 
+	
 	public <T> T convert(byte[] data, Class<T> cls) {
 		try {
 			byte[] converted = convertData(data);
@@ -33,12 +36,23 @@ public final class JsonDataConverter extends RdfFormatConverter {
 	}
 
 	public Map<String, Object> convert(byte[] data) {
+		byte[] converted = null;
 		try {
-			byte[] converted = convertData(data);
-			return objectMapper.readValue(converted, new TypeReference<>() {
+			converted = convertData(data);
+			ArrayList<Map<String, Object>> res = objectMapper.readValue(converted, new TypeReference<>() {
 			});
+			if (CollectionUtils.isNotEmpty(res)) {
+				return res.get(0);
+			}
 		} catch (DatabindException e) {
-			log.error("Could not deserialize data to a generic map", e);
+			// Just in case try to deserialize straight to a map without the outer list wrapper.
+			log.error("Could not deserialize data to a list of items. Will repeat and try to deserialize as a map instead.");
+			try {
+				return objectMapper.readValue(converted, new TypeReference<>() {
+				});
+			} catch (Exception e1) {
+				log.error("Could not deserialize data to a map. Cannot proceed", e);
+			}
 		} catch (StreamReadException e) {
 			log.error("Caught exception while reading data stream", e);
 		} catch (IOException e) {

--- a/src/main/java/com/ontotext/kafka/convert/JsonDataConverter.java
+++ b/src/main/java/com/ontotext/kafka/convert/JsonDataConverter.java
@@ -1,0 +1,72 @@
+package com.ontotext.kafka.convert;
+
+import com.fasterxml.jackson.core.exc.StreamReadException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DatabindException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ontotext.kafka.graphdb.template.ValueParser;
+import com.ontotext.kafka.util.ValueUtil;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.rio.RDFFormat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+
+public final class JsonDataConverter extends RdfFormatConverter {
+
+	private final ObjectMapper objectMapper;
+
+	public JsonDataConverter(RDFFormat inputFormat) {
+		super(inputFormat, RDFFormat.JSONLD);
+		this.objectMapper = new ObjectMapper();
+	}
+
+	public <T> T convert(byte[] data, Class<T> cls) {
+		try {
+			byte[] converted = convertData(data);
+			return objectMapper.readValue(converted, cls);
+		} catch (DatabindException e) {
+			log.error("Could not deserialize data to type {}", cls, e);
+		} catch (StreamReadException e) {
+			log.error("Caught exception while reading data stream", e);
+		} catch (IOException e) {
+			log.error("Could not convert data from {} to JSON", getInputFormat(), e);
+		}
+		return null;
+	}
+
+	public Map<String, Object> convert(byte[] data) {
+		try {
+			byte[] converted = convertData(data);
+			return objectMapper.readValue(converted, new TypeReference<>() {
+			});
+		} catch (DatabindException e) {
+			log.error("Could not deserialize data to a generic map", e);
+		} catch (StreamReadException e) {
+			log.error("Caught exception while reading data stream", e);
+		} catch (IOException e) {
+			log.error("Could not convert data from {} to JSON", getInputFormat(), e);
+		}
+		return null;
+	}
+
+	public static void main(String[] args) throws IOException {
+		byte[] data = Files.readAllBytes(Paths.get(args[0]));
+		JsonDataConverter converter = new JsonDataConverter(ValueUtil.getRDFFormat(args[1]));
+		Map<String, Object> map = converter.convert(data);
+		ObjectMapper objectMapper1 = new ObjectMapper();
+		System.out.println(objectMapper1.writerWithDefaultPrettyPrinter().writeValueAsString(map));
+		for (String key : map.keySet()) {
+			Object obj = map.get(key);
+			Value value = ValueParser.getValue(obj);
+			if (value == null) {
+				continue;
+			}
+			System.out.printf("%s : %s\n", key, value);
+		}
+	}
+
+
+}

--- a/src/main/java/com/ontotext/kafka/convert/JsonDataConverter.java
+++ b/src/main/java/com/ontotext/kafka/convert/JsonDataConverter.java
@@ -4,14 +4,9 @@ import com.fasterxml.jackson.core.exc.StreamReadException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DatabindException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ontotext.kafka.graphdb.template.ValueParser;
-import com.ontotext.kafka.util.ValueUtil;
-import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.rio.RDFFormat;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Map;
 
 public final class JsonDataConverter extends RdfFormatConverter {
@@ -51,22 +46,4 @@ public final class JsonDataConverter extends RdfFormatConverter {
 		}
 		return null;
 	}
-
-	public static void main(String[] args) throws IOException {
-		byte[] data = Files.readAllBytes(Paths.get(args[0]));
-		JsonDataConverter converter = new JsonDataConverter(ValueUtil.getRDFFormat(args[1]));
-		Map<String, Object> map = converter.convert(data);
-		ObjectMapper objectMapper1 = new ObjectMapper();
-		System.out.println(objectMapper1.writerWithDefaultPrettyPrinter().writeValueAsString(map));
-		for (String key : map.keySet()) {
-			Object obj = map.get(key);
-			Value value = ValueParser.getValue(obj);
-			if (value == null) {
-				continue;
-			}
-			System.out.printf("%s : %s\n", key, value);
-		}
-	}
-
-
 }

--- a/src/main/java/com/ontotext/kafka/convert/RdfFormatConverter.java
+++ b/src/main/java/com/ontotext/kafka/convert/RdfFormatConverter.java
@@ -1,0 +1,50 @@
+package com.ontotext.kafka.convert;
+
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.Rio;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+
+public class RdfFormatConverter {
+
+	protected final Logger log;
+	private final RDFFormat inputFormat;
+	private final RDFFormat outputFormat;
+
+	public RdfFormatConverter(RDFFormat inputFormat, RDFFormat outputFormat) {
+		this.inputFormat = inputFormat;
+		this.outputFormat = outputFormat;
+		this.log = LoggerFactory.getLogger(String.format("Converter [%s]->[%s]", inputFormat, outputFormat));
+	}
+
+
+	public byte[] convertData(byte[] inputData) throws IOException {
+		if (inputFormat.equals(outputFormat)) {
+			log.debug("Input and output formats [{}] are the same, skipping conversion", inputData);
+			return inputData;
+		}
+		log.debug("Converting data from {} to {}", inputFormat, outputFormat);
+		RDFParser rdfParser = Rio.createParser(inputFormat);
+		try (InputStream is = new ByteArrayInputStream(inputData);
+			 ByteArrayOutputStream baos = new ByteArrayOutputStream(1024);
+			 BufferedOutputStream bos = new BufferedOutputStream(baos)) {
+			RDFWriter rdfWriter = Rio.createWriter(outputFormat, bos);
+			rdfParser.setRDFHandler(rdfWriter);
+			rdfParser.parse(is);
+			return baos.toByteArray();
+		}
+	}
+
+
+	public RDFFormat getInputFormat() {
+		return inputFormat;
+	}
+
+	public RDFFormat getOutputFormat() {
+		return outputFormat;
+	}
+}

--- a/src/main/java/com/ontotext/kafka/graphdb/template/TemplateInput.java
+++ b/src/main/java/com/ontotext/kafka/graphdb/template/TemplateInput.java
@@ -1,0 +1,22 @@
+package com.ontotext.kafka.graphdb.template;
+
+import java.util.Map;
+
+public class TemplateInput {
+
+	private final String templateId;
+	private final Map<String, Object> data;
+
+	public TemplateInput(String templateId, Map<String, Object> data) {
+		this.templateId = templateId;
+		this.data = data;
+	}
+
+	public String getTemplateId() {
+		return templateId;
+	}
+
+	public Map<String, Object> getData() {
+		return data;
+	}
+}

--- a/src/main/java/com/ontotext/kafka/graphdb/template/TemplateUtil.java
+++ b/src/main/java/com/ontotext/kafka/graphdb/template/TemplateUtil.java
@@ -29,8 +29,7 @@ public final class TemplateUtil {
 			bindInput(input.getData(), update);
 			update.execute();
 		} catch (Exception e) {
-			e.printStackTrace();
-			// TODO
+			throw new RepositoryException("Caught exception while executing update", e);
 		}
 	}
 
@@ -61,7 +60,7 @@ public final class TemplateUtil {
 			throw new ConfigException("Did not find template with ID {}", templateId);
 		} catch (RepositoryException e) {
 			if (e instanceof UnauthorizedException) {
-				throw new ConfigException("Invalid credentials" + e.getMessage());
+				throw new ConfigException("Invalid credentials", e);
 			}
 			throw e;
 		}

--- a/src/main/java/com/ontotext/kafka/graphdb/template/TemplateUtil.java
+++ b/src/main/java/com/ontotext/kafka/graphdb/template/TemplateUtil.java
@@ -1,0 +1,69 @@
+package com.ontotext.kafka.graphdb.template;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.eclipse.rdf4j.http.protocol.UnauthorizedException;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.Update;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+public final class TemplateUtil {
+
+	private static final Logger LOG = LoggerFactory.getLogger(TemplateUtil.class);
+
+	private TemplateUtil() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	private static final String TEMPLATE_CONTENT_QUERY = "select ?template {\n <%s> <http://www.ontotext.com/sparql/template> ?template\n}";
+
+	public static void executeUpdate(RepositoryConnection connection, TemplateInput input) {
+		try {
+			Update update = prepareUpdate(input, connection);
+			bindInput(input.getData(), update);
+			update.execute();
+		} catch (Exception e) {
+			e.printStackTrace();
+			// TODO
+		}
+	}
+
+	private static void bindInput(Map<String, Object> input, Update update) {
+		for (String key : input.keySet()) {
+			Object obj = input.get(key);
+			Value value = ValueParser.getValue(obj);
+			if (value == null) {
+				LOG.warn("Binding for {} is null or empty. Skipping binding.", key);
+				continue;
+			}
+			update.setBinding(key, value);
+		}
+	}
+
+
+	private static Update prepareUpdate(TemplateInput input, RepositoryConnection connection) {
+		return connection.prepareUpdate(QueryLanguage.SPARQL, getSparqlTemplateContent(input.getTemplateId(), connection));
+	}
+
+	private static String getSparqlTemplateContent(String templateId, RepositoryConnection connection) {
+		LOG.debug("Querying template ID {}", templateId);
+		try (TupleQueryResult templates = connection.prepareTupleQuery(String.format(TEMPLATE_CONTENT_QUERY, templateId)).evaluate()) {
+			if (templates.hasNext()) {
+				// Only interested in first result
+				return templates.next().getValue("template").stringValue();
+			}
+			throw new ConfigException("Did not find template with ID {}", templateId);
+		} catch (RepositoryException e) {
+			if (e instanceof UnauthorizedException) {
+				throw new ConfigException("Invalid credentials" + e.getMessage());
+			}
+			throw e;
+		}
+	}
+}

--- a/src/main/java/com/ontotext/kafka/graphdb/template/ValueParser.java
+++ b/src/main/java/com/ontotext/kafka/graphdb/template/ValueParser.java
@@ -1,0 +1,155 @@
+package com.ontotext.kafka.graphdb.template;
+
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.rdf4j.common.net.ParsedIRI;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+
+public class ValueParser {
+
+	private static final SimpleValueFactory FACTORY = SimpleValueFactory.getInstance();
+	private static final String FORBIDDEN_SYMBOLS = "%<>\\{}|^` \"";
+	public static final String ID_TAG = "@id";
+	public static final String VALUE_TAG = "@value";
+	public static final String TYPE_TAG = "@type";
+	public static final String LANGUAGE_TAG = "@language";
+
+	private enum ValueType {
+		IRI, VALUE, TYPED_VALUE, LANGUAGE_VALUE, EMPTY
+	}
+
+
+	public static Value getValue(Object obj) {
+		if (obj == null) {
+			return null;
+		}
+		Class<?> klass = obj.getClass();
+		if (BigDecimal.class.equals(klass)) {
+			return FACTORY.createLiteral((BigDecimal) obj);
+		}
+		if (BigInteger.class.equals(klass)) {
+			return FACTORY.createLiteral((BigInteger) obj);
+		}
+		if (Long.class.equals(klass)) {
+			return FACTORY.createLiteral((Long) obj);
+		}
+		if (Integer.class.equals(klass)) {
+			return FACTORY.createLiteral((Integer) obj);
+		}
+		if (Short.class.equals(klass)) {
+			return FACTORY.createLiteral((Short) obj);
+		}
+		if (Byte.class.equals(klass)) {
+			return FACTORY.createLiteral((Byte) obj);
+		}
+		if (Double.class.equals(klass)) {
+			return FACTORY.createLiteral((Double) obj);
+		}
+		if (Float.class.equals(klass)) {
+			return FACTORY.createLiteral((Float) obj);
+		}
+		if (Boolean.class.equals(klass)) {
+			return FACTORY.createLiteral((Boolean) obj);
+		}
+		if (obj instanceof List) {
+			// only use first element, since we are dealing with single records
+			return getValue(((List<?>) obj).get(0));
+		}
+
+		if (obj instanceof Map) {
+			return new MapParser((Map<String, Object>) obj).parse();
+		}
+
+		// continue as String
+		String s = obj.toString();
+		if (StringUtils.isEmpty(s)) {
+			return null;
+		}
+		try {
+			new ParsedIRI(s);
+			return FACTORY.createIRI(s);
+		} catch (Exception e) {
+			// skip and process as simple string
+		}
+		return FACTORY.createLiteral(s);
+	}
+
+	private static class MapParser {
+		private final IRI id;
+		private final IRI type;
+		private final String value;
+		private final String language;
+		private final ValueType valueType;
+
+		MapParser(Map<String, Object> input) {
+			valueType = getValidState(input);
+			id = getIri(input.get(ID_TAG));
+			type = getIri(input.get(TYPE_TAG));
+			value = getString(input.get(VALUE_TAG));
+			language = getString(input.get(LANGUAGE_TAG));
+		}
+
+		private ValueType getValidState(Map<String, Object> input) {
+			int size = input.size();
+			if (size == 0) {
+				return ValueType.EMPTY;
+			} else if (size == 1) {
+				if (input.containsKey(ID_TAG)) {
+					return ValueType.IRI;
+				} else if (input.containsKey(VALUE_TAG)) {
+					return ValueType.VALUE;
+				}
+			} else if (size == 2) {
+				if (input.containsKey(VALUE_TAG)) {
+					if (input.containsKey(TYPE_TAG)) {
+						return ValueType.TYPED_VALUE;
+					} else if (input.containsKey(LANGUAGE_TAG)) {
+						return ValueType.LANGUAGE_VALUE;
+					}
+				}
+			}
+			throw new IllegalArgumentException("Can't parse " + input + " to Value.");
+		}
+
+		private String getString(Object val) {
+			return (val == null) ? null : "" + val;
+		}
+
+		Value parse() {
+			switch (valueType) {
+				case EMPTY:
+					return null;
+				case IRI:
+					return getIri(id);
+				case VALUE:
+					return FACTORY.createLiteral(value);
+				case TYPED_VALUE:
+					return FACTORY.createLiteral(value, type);
+				case LANGUAGE_VALUE:
+					return FACTORY.createLiteral(value, language);
+				default:
+					throw new IllegalArgumentException("Should not get to here. Stateless map.");
+			}
+		}
+
+		private IRI getIri(Object iriObj) {
+			if (iriObj == null) {
+				return null;
+			}
+			String sIri = iriObj.toString();
+			try {
+				new ParsedIRI(sIri);
+				return FACTORY.createIRI(sIri);
+			} catch (Exception e) {
+				throw new IllegalArgumentException("Can't parse {" + iriObj + "} to IRI.", e);
+			}
+		}
+	}
+
+}

--- a/src/main/java/com/ontotext/kafka/processor/SinkRecordsProcessor.java
+++ b/src/main/java/com/ontotext/kafka/processor/SinkRecordsProcessor.java
@@ -63,7 +63,7 @@ public final class SinkRecordsProcessor implements Runnable {
 		this.timeoutCommitMs = config.getProcessorRecordPollTimeoutMs();
 		this.errorHandler = new LogErrorHandler(config);
 		this.transactionType = config.getTransactionType();
-		this.recordHandler = RecordHandler.getRecordHandler(transactionType);
+		this.recordHandler = RecordHandler.getRecordHandler(config);
 		this.initOperators(config);
 		// repositoryUrl is used for logging purposes
 		MDC.put("RepositoryURL", repositoryManager.getRepositoryURL());

--- a/src/main/java/com/ontotext/kafka/util/EnumValidator.java
+++ b/src/main/java/com/ontotext/kafka/util/EnumValidator.java
@@ -6,11 +6,11 @@ import org.apache.kafka.common.config.ConfigException;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-public class ValidateEnum implements ConfigDef.Validator {
+public class EnumValidator implements ConfigDef.Validator {
 	final Set<String> validEnums;
 	final Class<?> enumClass;
 
-	public ValidateEnum(Class<?> enumClass) {
+	public EnumValidator(Class<?> enumClass) {
 		Set<String> validEnums = new LinkedHashSet<>();
 		for (Object o : enumClass.getEnumConstants()) {
 			String key = o.toString().toLowerCase();

--- a/src/main/java/com/ontotext/kafka/util/RDFFormatValidator.java
+++ b/src/main/java/com/ontotext/kafka/util/RDFFormatValidator.java
@@ -3,7 +3,7 @@ package com.ontotext.kafka.util;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
-public class ValidateRDFFormat implements ConfigDef.Validator {
+public class RDFFormatValidator implements ConfigDef.Validator {
 	@Override
 	public void ensureValid(final String key, final Object value) {
 

--- a/src/main/java/com/ontotext/kafka/util/ValueUtil.java
+++ b/src/main/java/com/ontotext/kafka/util/ValueUtil.java
@@ -6,7 +6,8 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.RDFFormat;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.Charset;
 import java.util.Objects;
 
 public class ValueUtil {
@@ -53,12 +54,12 @@ public class ValueUtil {
 		}
 	}
 
-	public static Reader convertRDFData(Object obj) {
+	public static ByteArrayInputStream convertRDFData(Object obj) {
 		Objects.requireNonNull(obj, "Cannot parse null objects");
 		if (obj instanceof byte[]) {
-			return new BufferedReader(new InputStreamReader(new ByteArrayInputStream((byte[]) obj)));
+			return new ByteArrayInputStream((byte[]) obj);
 		} else {
-			return new StringReader(convertValueToString(obj));
+			return new ByteArrayInputStream(convertValueToString(obj).getBytes(Charset.defaultCharset()));
 		}
 	}
 

--- a/src/test/java/com/ontotext/kafka/convert/JsonDataConverterTest.java
+++ b/src/test/java/com/ontotext/kafka/convert/JsonDataConverterTest.java
@@ -1,0 +1,24 @@
+package com.ontotext.kafka.convert;
+
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+class JsonDataConverterTest {
+
+
+	@Test
+	void test_convertToMap_ok() {
+		String ttl = "<urn:a> <urn:b> <urn:c> .";
+		JsonDataConverter converter = new JsonDataConverter(RDFFormat.TURTLE);
+		Map<String, Object> data = converter.convert(ttl.getBytes(StandardCharsets.UTF_8));
+		assertThat(data).isNotNull();
+		assertThat(data).containsEntry("@id", "urn:a");
+		assertThat(data).containsEntry("urn:b", Collections.singletonList(Collections.singletonMap("@id", "urn:c")));
+	}
+}

--- a/src/test/java/com/ontotext/kafka/convert/RdfFormatConverterTest.java
+++ b/src/test/java/com/ontotext/kafka/convert/RdfFormatConverterTest.java
@@ -1,0 +1,47 @@
+package com.ontotext.kafka.convert;
+
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.eclipse.rdf4j.rio.RDFFormat.JSONLD;
+import static org.eclipse.rdf4j.rio.RDFFormat.TURTLE;
+
+class RdfFormatConverterTest {
+
+
+	@Test
+	void test_convertTurtleToJsonLD_and_back_ok() throws IOException {
+		RdfFormatConverter converter = new RdfFormatConverter(TURTLE, JSONLD);
+		String ttl = "<urn:a> <urn:b> <urn:c> .";
+		byte[] converted = converter.convertData(ttl.getBytes(Charset.defaultCharset()));
+		assertThat(converted).isNotEmpty();
+		converter = new RdfFormatConverter(JSONLD, TURTLE);
+		byte[] reverseConverted = converter.convertData(converted);
+		assertThat(reverseConverted).isNotEmpty();
+		String s = new String(reverseConverted, Charset.defaultCharset());
+		assertThat(s.trim()).isEqualTo(ttl);
+	}
+
+	@Test
+	void test_convertInvalidDataToJsonLD_fail() throws IOException {
+		RdfFormatConverter converter = new RdfFormatConverter(TURTLE, JSONLD);
+		String ttl = "<urn:a> <urn:b> <urn:c> INVALID";
+		assertThatCode(() -> converter.convertData(ttl.getBytes(Charset.defaultCharset()))).isInstanceOf(RDFParseException.class)
+			.hasMessageContaining("Expected '.', found 'I'");
+	}
+
+	@Test
+	void test_convertJsonLD_toJsonLD_skipConversionAndReturnData() {
+		// Test with invalid data to verify that no actual conversion takes place
+		RdfFormatConverter converter = new RdfFormatConverter(TURTLE, TURTLE);
+		String ttl = "<urn:a> <urn:b> <urn:c> INVALID";
+		assertThatCode(() -> converter.convertData(ttl.getBytes(Charset.defaultCharset()))).as(
+			"Conversion between same formats does not take place, thus exception is not thrown").doesNotThrowAnyException();
+	}
+
+}

--- a/src/test/java/com/ontotext/kafka/processor/SinkRecordsProcessorTest.java
+++ b/src/test/java/com/ontotext/kafka/processor/SinkRecordsProcessorTest.java
@@ -170,7 +170,7 @@ public class SinkRecordsProcessorTest {
 			RecordHandler handlerMock = (record, connection, config1) -> {
 			};
 
-			mockedStatic.when(() -> RecordHandler.getRecordHandler(eq(GraphDBSinkConfig.TransactionType.ADD))).thenReturn(handlerMock);
+			mockedStatic.when(() -> RecordHandler.getRecordHandler(any())).thenReturn(handlerMock);
 
 			processor = spy(new SinkRecordsProcessor(config, sinkRecords, repositoryMgr));
 			assertThat(processor.handleRecord(generateSinkRecord(2), null)).isNull();
@@ -187,7 +187,7 @@ public class SinkRecordsProcessorTest {
 			RecordHandler handlerMock = (record, connection, config1) -> {
 				throw new IOException("IOException");
 			};
-			mockedStatic.when(() -> RecordHandler.getRecordHandler(eq(GraphDBSinkConfig.TransactionType.ADD))).thenReturn(handlerMock);
+			mockedStatic.when(() -> RecordHandler.getRecordHandler(any())).thenReturn(handlerMock);
 
 			processor = spy(new SinkRecordsProcessor(config, sinkRecords, repositoryMgr));
 			assertThatCode(() -> processor.handleRecord(generateSinkRecord(2), null)).isInstanceOf(RetriableException.class).hasMessage("IOException");


### PR DESCRIPTION
- Add validation for provided templateId - the template given the ID must already exist in GraphDB
- Fix missing bound input to template smart-update - see https://graphdb.ontotext.com/documentation/10.8/updating-data.html#sparql-template-endpoint Example 1
- Copy template update operations and parsing from SparQLTemplateService in GraphDB
- Add generic RDF format converter